### PR TITLE
Update README for the GA release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,50 +1,50 @@
 OpenJDK for Windows 10 ARM64
 =====
 
-This project only holds early access binaries of the initial port of OpenJDK for Windows on ARM64 devices and some accompanying documentation.
+This project holds binaries and documentation about the initial port of OpenJDK for Windows on ARM64 devices, as well as ARM64 binaries built by Microsoft for all operating systems supported by the OpenJDK project.
 
 * See our [Contributing Guide](CONTRIBUTING.md).  **Please note** source code contributions are welcome through the [OpenJDK project](https://openjdk.java.net/contribute/). 
 * Our [Code of Conduct](CODE_OF_CONDUCT.md).
 
-*Early Access* binaries are available in the [releases](https://github.com/microsoft/openjdk-aarch64/releases) tab for experimentation.
+General Access (GA) binaries are available under the [releases](https://github.com/microsoft/openjdk-aarch64/releases) tab.
 
-## JDK Enhancement Proposal
+### JDK Enhancement Proposal
 The JEP can be found at [https://openjdk.java.net/jeps/388](https://openjdk.java.net/jeps/388).
 
 This JEP was tracked under the [JDK-8248496](https://bugs.openjdk.java.net/browse/JDK-8248496) work item and has been delivered in JDK 16.
 
-## Source Code
+### Source Code
 All source code changes to OpenJDK, that were required to implement this port, were being tracked under [JDK-8248238 Implementation of JEP: Windows AArch64 Support](https://bugs.openjdk.java.net/browse/JDK-8248238).
 
 The source code is merged into JDK 16 and is now a part of the [OpenJDK project](https://github.com/openjdk/jdk). 
 Here's a [link to the source code for our JDK 16u EA build](https://download.visualstudio.microsoft.com/download/pr/df5d5fd6-decb-4eea-8c08-895c5b088439/edb7b06196fae4471a3c241e092f2eda/jdk16u.tar.gz).
 
 
-## Supported Windows Versions
+### Supported Windows Versions
 
 - Windows 10
 - Windows Server 2016
 
-## Supported Garbage Collectors
+### Supported Garbage Collectors
 - Serial GC
 - Parallel GC
 - G1 GC
-- Z GC
+- ZGC
 - Shenandoah GC
 
-## FAQ
+### FAQ
 
-### Is this build TCK'ed?
+#### Is this build TCK'ed?
 
-Early Access binaries will not be TCK'ed. 
+Yes.
 
-### Where can I test this build?
+#### Where can I test this build?
 
 We have uploaded our Arm64 test systems information [here](https://github.com/microsoft/openjdk-aarch64/blob/master/Arm64_systems.md). You can find retail laptops with ARM64 and Windows, such as HP Enxy x2, Asus NovaGo, and the Microsoft Surface Pro X.
 
-For additional information, please visit [Works on Arm](https://www.worksonarm.com/?_ga=2.204290832.1614868344.1591633956-103015898.1581534333) website.
+For additional information, please visit the [Works on Arm](https://www.worksonarm.com/?_ga=2.204290832.1614868344.1591633956-103015898.1581534333) website.
 
-### What Java tools run on this build?
+#### What Java tools run on this build?
 
 The following tools have been tested, though not extensively, and did not show any immediate issues:
 
@@ -53,11 +53,11 @@ The following tools have been tested, though not extensively, and did not show a
 - Gradle
 - Visual Studio Code Java Extension Pack
 
-## Build dependencies
+### Build dependencies
 
 We rely on VS 2019 and the following individual components:
--	MSVC v142 - VS 2019 C++ ARM64 build tools (v14.26)
--	MSVC v142 - VS 2019 C++ x64/x86 build tools (v14.26)
+-	MSVC v142 - VS 2019 C++ ARM64 build tools (latest)
+-	MSVC v142 - VS 2019 C++ x64/x86 build tools (latest)
 -	C++ ATL for latest v142 build tools (ARM64)
 -	C++ ATL for latest v142 build tools (x86 & x64)
 -	C++ MFC for latest v142 build tools (ARM64)
@@ -66,24 +66,26 @@ We rely on VS 2019 and the following individual components:
 
 Other dependencies are:
 -	Cygwin
--	Java 16 for boot and build JDK 
+-	Boot and build JDK:
+    - Java 11 is needed to build JDK 11
+    - Java 16 is needed to build JDK 16
 
-### Building from github.com/openjdk/jdk.git
+#### Building JDK 16 from github.com/openjdk/jdk.git
 
 ```shell
 $ bash configure
           --openjdk-target=aarch64-unknown-cygwin
           --with-boot-jdk=<path-to-x86_64-JDK>
 ```
-### Building JDK11
+#### Building JDK 11
 
-(Note that the backport is not merged yet, a branch exists here: https://github.com/openjdk/jdk11u/pull/2 )
+Note that the backport is not merged into the official OpenJDK repository yet. A recent version of our branch can be checked out from https://github.com/openjdk/jdk11u/pull/2.
 
 Configure this way:
 ```
-$ DEVKIT="/cygdrive/c/work/VS2019-16.6.1-devkit" \
-    BOOTJDK="/cygdrive/c/work/jdk_x64_windows/jdk-11.0.10+8" \
-     bash configure \
+$ export DEVKIT="/cygdrive/c/work/VS2019-16.6.1-devkit"
+$ export BOOTJDK="/cygdrive/c/work/jdk_x64_windows/jdk-11.0.10+8"
+$ bash configure \
     --openjdk-target=aarch64-unknown-cygwin \  
     --with-devkit="$DEVKIT" \  
     --with-build-devkit="$DEVKIT" \  
@@ -92,17 +94,33 @@ $ DEVKIT="/cygdrive/c/work/VS2019-16.6.1-devkit" \
 ```
 
 Note that:
-* Usage of a devkit is required. Must be created from a VS2019 installation. The jdk11u repository only contains a script for VS2017, so one from e.g. jdk16u has to be used: https://github.com/openjdk/jdk16u/blob/master/make/devkit/createWindowsDevkit2019.sh
+* Usage of a devkit is required. Must be created from a VS 2019 installation. The jdk11u repository only contains a script for VS 2017, so [one from e.g. jdk16u](https://github.com/openjdk/jdk16u/blob/master/make/devkit/createWindowsDevkit2019.sh) has to be used.
 * Both `build-jdk` _and_ `boot-jdk` must be specified.
 * Build must happen on a `x86_64` machine.
 * If you want to enable ShenandoahGC in this build, you have to explicitly enable it via: `--with-jvm-features=shenandoahgc`.
+* The [fixpath binary](https://github.com/microsoft/openjdk-aarch64/releases/tag/fp-1.0) available under the releases tab has to be placed at the root of the source tree.
 
-#### Why is this more complicated than on >= jdk16u?
+##### Why is this more complicated than on >= jdk16u?
 
-Because the WINENV patch has not been backported which adds proper cross-compilation for Windows: https://github.com/openjdk/jdk/pull/1597
+The [WINENV patch](https://github.com/openjdk/jdk/pull/1597) that adds proper cross-compilation support for Windows has not been backported to JDK 11.
+
+
+### OpenJDK binaries built by Microsoft for ARM64 devices
+
+General Access (GA) ARM64 binaries are available for the following operating systems under the [releases](https://github.com/microsoft/openjdk-aarch64/releases) tab:
+
+
+|        | Linux | Windows | MacOS |
+|--------|-------|---------|-------|
+| JDK 11 | [:floppy_disk:](https://github.com/microsoft/openjdk-aarch64/releases/download/jdk-11.0.12-ga/microsoft-jdk-11.0.12.7.1-linux-aarch64.tar.gz) | [:floppy_disk:](https://github.com/microsoft/openjdk-aarch64/releases/download/jdk-11.0.12-ga/microsoft-jdk-11.0.12.7.1-windows-aarch64.msi)<sup>1</sup> | :x:<sup>2</sup> |
+| JDK 16 | [:floppy_disk:](https://github.com/microsoft/openjdk-aarch64/releases/download/jdk-16.0.2-ga/microsoft-jdk-16.0.2.7.1-linux-aarch64.tar.gz)   | [:floppy_disk:](https://github.com/microsoft/openjdk-aarch64/releases/download/jdk-16.0.2-ga/microsoft-jdk-16.0.2.7.1-windows-aarch64.msi)     | [:floppy_disk:](https://github.com/microsoft/openjdk-aarch64/releases/download/jdk-16.0.2-ga/microsoft-jdk-16.0.2.7.1-macos-aarch64.pkg)   |
+
+<sup>1</sup> Upstreaming in progress.
+<sup>2</sup> Coming soon.
+
 
 ## Feedback
 
-Please send email to [aarch64-port-dev@openjdk.java.net](http://mail.openjdk.java.net/mailman/listinfo/aarch64-port-dev). 
+Please send any emails to [aarch64-port-dev@openjdk.java.net](http://mail.openjdk.java.net/mailman/listinfo/aarch64-port-dev).
 
 Microsoft is committed to working on an *upstream first* approach, so please reach out through the mailing list above. If you do want to contact the Microsoft team directly, please email openjdk-aarch64@microsoft.com.


### PR DESCRIPTION
- Instead of the EA releases, reference the GA releases.
- Because we're uploading all AArch64 binaries, not only Windows, I updated the intro to reflect that, and added a small section to the end with download links.
- In my (and Bubae's) experience, v14.26 MSVC build tools are no longer enough to build JDK 11. One needs the "latest" packages instead.
- Added a reference to the fixpath binary in the JDK 11 build instructions.
- A few tiny cosmetic fixes.